### PR TITLE
ArrayList resize 코드 작성

### DIFF
--- a/src/main/ArrList.java
+++ b/src/main/ArrList.java
@@ -31,8 +31,14 @@ public class ArrList<E> {
      * <br>1 2 3
      */
     private void resize(int newSize) {
-        // TODO resize 함수를 완성하시오.
+        E temp[] = (E[]) new Object[newSize];
+
+        for (int i=0;i<Math.min(a.length, temp.length);i++) 
+            temp[i] = a[i];
+
+        a = temp;
     }
+
 
     public E deleteLast() {
         return delete(size-1);


### PR DESCRIPTION
resize는 작아질 때도 메모리 공간의 효율성을 위해, 사용 될 수 있습니다.

즉, a.length 만큼, 탐색하는 것은 더 줄어든 새로운 배열의 OutofIndex 예외를 일으 킬 수 있습니다.
따라서, Math.min(a.length, temp.length)까지, a의 배열 원소를 새로운 배열에 할당 해 주어야 합니다.